### PR TITLE
Fix typo in concatMap example

### DIFF
--- a/src/Data/Composition.hs
+++ b/src/Data/Composition.hs
@@ -63,7 +63,7 @@ infixr 9 ∘
 --
 -- Example usage:
 --
--- > concatMap :: (a -> b) -> [a] -> [b]
+-- > concatMap :: (a -> [b]) -> [a] -> [b]
 -- > concatMap = concat .: map
 --
 -- Notice how /two/ arguments


### PR DESCRIPTION
The type should be

```haskell
concatMap :: (a -> [b]) -> [a] -> [b]
```

rather than

```haskell
concatMap :: (a -> b) -> [a] -> [b]
```