### PR TITLE
Fix to support upcoming GHC 10.2

### DIFF
--- a/composition.cabal
+++ b/composition.cabal
@@ -18,6 +18,10 @@ library
   hs-source-dirs:      src
   exposed-modules:     Data.Composition
   default-extensions:  NoImplicitPrelude
+  if(impl(ghc >= 10.1))
+    -- removes the implicit dependency on GHC.Essentials
+    -- (we'd need a dependency on base to satisfy it otherwise)
+    ghc-options: -frebindable-known-names
 
 source-repository head
   type:     git


### PR DESCRIPTION
Starting with GHC 10.2, the "built-in" names known-to-the-compiler are found in a module called GHC.Essentials (provided by `base`).

Notably, this package does not need any of these known-names at the moment. However, by default, GHC adds a dependency on GHC.Essentials unless -frebindable-known-names is given. But `composition` doesn't depend on any library (no `base` nor `ghc-internal`!), so that implicit dependency can't be satisfied.

So, just toggle -frebindable-known-names. If the package ever happens to need a known-name, it will either have to bring it into scope via an import directly from ghc-internal (not really recommended), or it will require a dependency on `base` to fulfill the `GHC.Essentials` dependency (at which point, drop `-frebindable-known-names`)